### PR TITLE
BOT-20230102

### DIFF
--- a/clean.ps1
+++ b/clean.ps1
@@ -7,7 +7,7 @@ Function remove {
     param([string]$item)
     If (Test-Path $item){
 		if (-not $quiet.IsPresent) {
-			Write-Host "Removing $item"
+			Write-Output "Removing $item"
 		}
         Remove-Item $item -Force -Recurse
     }
@@ -15,13 +15,13 @@ Function remove {
 
 Function Invoke-Cleanup {
 	if (-not $quiet.IsPresent) {
-		Write-Host "---------------------"
-		Write-Host "Invoke-Cleanup"
-		Write-Host "---------------------"
+		Write-Output "---------------------"
+		Write-Output "Invoke-Cleanup"
+		Write-Output "---------------------"
 	}
 
 	# clean package, bin and obj folders
-	Get-ChildItem .\ -include packages,bin,obj,node_modules -Recurse | Where-Object {$_.FullName -NotMatch "BuildScripts"} | foreach ($_) { Write-Host "Removing " + $_.fullname; remove-item $_.fullname -Force -Recurse }
+	Get-ChildItem .\ -include packages,bin,obj,node_modules -Recurse | Where-Object {$_.FullName -NotMatch "BuildScripts"} | foreach ($_) { Write-Host "Removing $($_.fullname)"; remove-item $_.fullname -Force -Recurse }
 
 	#Find nunit files
 	Get-ChildItem -include *.nunit -Recurse |
@@ -30,7 +30,7 @@ Function Invoke-Cleanup {
 			Write-Host $_
 		}
 
-		$results = $_.BaseName + ".xml"
+		$results = "$($_.BaseName).xml"
 		If (Test-Path $results){
 				if (-not $quiet.IsPresent) {
 					Write-Host "Removing $results"

--- a/src/Cortside.Common.Messages.Tests/Cortside.Common.Messages.Tests.csproj
+++ b/src/Cortside.Common.Messages.Tests/Cortside.Common.Messages.Tests.csproj
@@ -14,7 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Moq" Version="4.18.3" />
+    <PackageReference Include="Moq" Version="4.18.4" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Tool 'dotnet-outdated-tool' was reinstalled with the latest stable version (version '4.3.2'). Discovering projects... Analyzing project(s)... Analyzing dependencies... ┬╗ Cortside.Common.Messages.Tests   [.NETCoreApp,Version=v3.1]   Moq  4.18.3 -> 4.18.4  Version color legend: <red>   : Major version update or pre-release version. Possible breaking changes. <yellow>: Minor version update. Backwards-compatible features added. <green> : Patch version update. Backwards-compatible bug fixes.  Upgrading package Moq... Project Cortside.Common.Messages.Tests [.NETCoreApp,Version=v3.1] upgraded successfully  Elapsed: 00:00:04.4558427